### PR TITLE
fix shadowed declarations

### DIFF
--- a/include/libyang-cpp/Value.hpp
+++ b/include/libyang-cpp/Value.hpp
@@ -142,9 +142,9 @@ struct LIBYANG_CPP_EXPORT Decimal64 {
         static_assert(digits <= 18);
         return Decimal64{impl::llround(value * impl::pow10int(digits)), digits};
     }
-    explicit constexpr Decimal64(const int64_t number, const uint8_t digits)
-        : number(number)
-        , digits(digits)
+    explicit constexpr Decimal64(const int64_t number_, const uint8_t digits_)
+        : number(number_)
+        , digits(digits_)
     {
     }
 


### PR DESCRIPTION
Compiling a third party app which includes headers from an installed libyang-cpp with `-Wshadow` shows these warnings.

```cpp
/opt/libyang-cpp/include/libyang-cpp/Value.hpp: In constructor ‘constexpr libyang::Decimal64::Decimal64(int64_t, uint8_t)’:
/opt/libyang-cpp/include/libyang-cpp/Value.hpp:145:70: warning: declaration of ‘digits’ shadows a member of ‘libyang::Decimal64’ [-Wshadow]
  145 |     explicit constexpr Decimal64(const int64_t number, const uint8_t digits)
      |                                                        ~~~~~~~~~~~~~~^~~~~~
/opt/libyang-cpp/include/libyang-cpp/Value.hpp:118:13: note: shadowed declaration is here
  118 |     uint8_t digits;
      |             ^~~~~~
/opt/libyang-cpp/include/libyang-cpp/Value.hpp:145:48: warning: declaration of ‘number’ shadows a member of ‘libyang::Decimal64’ [-Wshadow]
  145 |     explicit constexpr Decimal64(const int64_t number, const uint8_t digits)
      |                                  ~~~~~~~~~~~~~~^~~~~~
/opt/libyang-cpp/include/libyang-cpp/Value.hpp:117:13: note: shadowed declaration is here
  117 |     int64_t number;
      |             ^~~~~~
/opt/libyang-cpp/include/libyang-cpp/Value.hpp: In constructor ‘constexpr libyang::Decimal64::Decimal64(int64_t, uint8_t)’:
/opt/libyang-cpp/include/libyang-cpp/Value.hpp:145:70: warning: declaration of ‘digits’ shadows a member of ‘libyang::Decimal64’ [-Wshadow]
  145 |     explicit constexpr Decimal64(const int64_t number, const uint8_t digits)
      |                                                        ~~~~~~~~~~~~~~^~~~~~
/opt/libyang-cpp/include/libyang-cpp/Value.hpp:118:13: note: shadowed declaration is here
  118 |     uint8_t digits;
      |             ^~~~~~
/opt/libyang-cpp/include/libyang-cpp/Value.hpp:145:48: warning: declaration of ‘number’ shadows a member of ‘libyang::Decimal64’ [-Wshadow]
  145 |     explicit constexpr Decimal64(const int64_t number, const uint8_t digits)
      |                                  ~~~~~~~~~~~~~~^~~~~~
/opt/libyang-cpp/include/libyang-cpp/Value.hpp:117:13: note: shadowed declaration is here
  117 |     int64_t number;
      |             ^~~~~~
/opt/libyang-cpp/include/libyang-cpp/Value.hpp: In constructor ‘constexpr libyang::Decimal64::Decimal64(int64_t, uint8_t)’:
/opt/libyang-cpp/include/libyang-cpp/Value.hpp:145:70: warning: declaration of ‘digits’ shadows a member of ‘libyang::Decimal64’ [-Wshadow]
  145 |     explicit constexpr Decimal64(const int64_t number, const uint8_t digits)
      |                                                        ~~~~~~~~~~~~~~^~~~~~
/opt/libyang-cpp/include/libyang-cpp/Value.hpp:118:13: note: shadowed declaration is here
  118 |     uint8_t digits;
      |             ^~~~~~
/opt/libyang-cpp/include/libyang-cpp/Value.hpp:145:48: warning: declaration of ‘number’ shadows a member of ‘libyang::Decimal64’ [-Wshadow]
  145 |     explicit constexpr Decimal64(const int64_t number, const uint8_t digits)
      |                                  ~~~~~~~~~~~~~~^~~~~~
/opt/libyang-cpp/include/libyang-cpp/Value.hpp:117:13: note: shadowed declaration is here
  117 |     int64_t number;
      |             ^~~~~~
```

While they may be considered harmless, having the warnings show up for each translation unit makes the output verbose and prevents the developer to find shadowed declarations in his own app.

There are no other warnings shown in the other repos `libyang`, `sysrepo`, or `sysrepo-cpp`. These are the only ones that I get.

Was wondering whether you're willing to accept this change for a better compiling experience. Tried to respect the syntax from other classes of having `m_` prepended to members.