### PR TITLE
fix 'not a member' error when compiling

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -11,6 +11,7 @@
 #include <libyang-cpp/SchemaNode.hpp>
 #include <libyang-cpp/Utils.hpp>
 #include <libyang/libyang.h>
+#include <algorithm>
 #include <span>
 #include <stdexcept>
 #include "utils/deleters.hpp"

--- a/tests/example_schema.hpp
+++ b/tests/example_schema.hpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
 */
 
+#include <algorithm>
 #include <string>
 
 using namespace std::literals;


### PR DESCRIPTION
the following error occurs for building the library and the tests:

building the library:
```
libyang-cpp/src/Context.cpp: In function ‘std::vector<const char*> libyang::{anonymous}::toCStringArray(const std::vector<std::__cxx11::basic_string<char> >&)’:
libyang-cpp/src/Context.cpp:81:10: error: ‘transform’ is not a member of ‘std’
   81 |     std::transform(vec.begin(), vec.end(), std::back_inserter(res), [](const auto& x) { return x.c_str(); });
      |          ^~~~~~~~~
make[2]: *** [CMakeFiles/yang-cpp.dir/build.make:90: CMakeFiles/yang-cpp.dir/src/Context.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:140: CMakeFiles/yang-cpp.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

building tests:
```
In file included from libyang-cpp/tests/schema_node.cpp:14:
libyang-cpp/tests/pretty_printers.hpp: In function ‘doctest::String std::toString(const vector<pair<__cxx11::basic_string<char>, __cxx11::basic_string<char> > >&)’:
libyang-cpp/tests/pretty_printers.hpp:33:10: error: ‘transform’ is not a member of ‘std’
   33 |     std::transform(vec.begin(), vec.end(), std::experimental::make_ostream_joiner(oss, ",\n    "), [] (auto pair) { return "{" + pair.first + ", " + pair.second + "}"; });
      |          ^~~~~~~~~
libyang-cpp/tests/pretty_printers.hpp: In function ‘doctest::String std::toString(const vector<libyang::ErrorInfo>&)’:
libyang-cpp/tests/pretty_printers.hpp:56:10: error: ‘transform’ is not a member of ‘std’
   56 |     std::transform(errors.begin(), errors.end(), std::experimental::make_ostream_joiner(oss, ",\n   "), [] (const libyang::ErrorInfo err) {
      |          ^~~~~~~~~
In file included from libyang-cpp/tests/context.cpp:14:
libyang-cpp/tests/pretty_printers.hpp: In function ‘doctest::String std::toString(const vector<pair<__cxx11::basic_string<char>, __cxx11::basic_string<char> > >&)’:
libyang-cpp/tests/pretty_printers.hpp:33:10: error: ‘transform’ is not a member of ‘std’
   33 |     std::transform(vec.begin(), vec.end(), std::experimental::make_ostream_joiner(oss, ",\n    "), [] (auto pair) { return "{" + pair.first + ", " + pair.second + "}"; });
      |          ^~~~~~~~~
libyang-cpp/tests/pretty_printers.hpp: In function ‘doctest::String std::toString(const vector<libyang::ErrorInfo>&)’:
libyang-cpp/tests/pretty_printers.hpp:56:10: error: ‘transform’ is not a member of ‘std’
   56 |     std::transform(errors.begin(), errors.end(), std::experimental::make_ostream_joiner(oss, ",\n   "), [] (const libyang::ErrorInfo err) {
      |          ^~~~~~~~~
libyang-cpp/tests/pretty_printers.hpp: In function ‘doctest::String libyang::toString(const std::vector<DataNode>&)’:
libyang-cpp/tests/pretty_printers.hpp:102:10: error: ‘transform’ is not a member of ‘std’
  102 |     std::transform(nodes.begin(), nodes.end(), std::experimental::make_ostream_joiner(oss, ", "), [](const DataNode& node) {
      |          ^~~~~~~~~
libyang-cpp/tests/pretty_printers.hpp: In function ‘doctest::String libyang::toString(const std::vector<DataNode>&)’:
libyang-cpp/tests/pretty_printers.hpp:102:10: error: ‘transform’ is not a member of ‘std’
  102 |     std::transform(nodes.begin(), nodes.end(), std::experimental::make_ostream_joiner(oss, ", "), [](const DataNode& node) {
      |          ^~~~~~~~~
libyang-cpp/tests/context.cpp: In function ‘void DOCTEST_ANON_FUNC_2()’:
libyang-cpp/tests/context.cpp:224:14: error: ‘transform’ is not a member of ‘std’
  224 |         std::transform(allIdentities.begin(), allIdentities.end(), std::back_inserter(actual), libyang::qualifiedName);
      |              ^~~~~~~~~
```

running Arch with latest updated as of today. GCC 14.1.1 20240522